### PR TITLE
Use translation JSON resources

### DIFF
--- a/src/localization/i18n.js
+++ b/src/localization/i18n.js
@@ -1,6 +1,8 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
+import enTranslation from "./en/translation.json";
+import arTranslation from "./ar/translation.json";
 
 i18n
     .use(LanguageDetector) // detect language from browser
@@ -8,16 +10,10 @@ i18n
     .init({
         resources: {
             en: {
-                translation: {
-                    welcome: "Welcome to our platform",
-                    view_pricing: "View Pricing",
-                },
+                translation: enTranslation,
             },
             ar: {
-                translation: {
-                    welcome: "مرحباً بك في منصتنا",
-                    view_pricing: "عرض الأسعار",
-                },
+                translation: arTranslation,
             },
         },
         fallbackLng: "en", // default lan


### PR DESCRIPTION
## Summary
- import the bundled English and Arabic translation JSON files in the i18n setup
- wire the i18next resources to use the external translation payloads while keeping existing configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cc18ffcf38832ea7d87597dbb2c956