### PR TITLE
Localize navbar content with translations

### DIFF
--- a/src/Navbar/Nav.jsx
+++ b/src/Navbar/Nav.jsx
@@ -1,24 +1,32 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import MyButton from "../Component/MyButton";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../context/AuthContext";
 
 export default function Nav() {
-	const { user, logout } = useAuth();
-	const [isMenuOpen, setIsMenuOpen] = useState(false);
-	const { i18n } = useTranslation();
+        const { user, logout } = useAuth();
+        const [isMenuOpen, setIsMenuOpen] = useState(false);
+        const { t, i18n } = useTranslation();
+        const userName = user?.displayName || user?.email;
 
-	const toggleLang = () => {
-		i18n.changeLanguage(i18n.language === "en" ? "ar" : "en");
-	};
+        useEffect(() => {
+                document.documentElement.dir = i18n.language === "ar" ? "rtl" : "ltr";
+        }, [i18n.language]);
+
+        const toggleLang = () => {
+                const newLanguage = i18n.language === "en" ? "ar" : "en";
+                i18n.changeLanguage(newLanguage);
+                document.documentElement.dir = newLanguage === "ar" ? "rtl" : "ltr";
+        };
 
 	return (
 		<>
-			<p className="bg-[#ff9500] text-white m-0 p-2 text-center ">
-				Free Course <i className="fa-solid fa-star text-yellow-400"></i> Sale
-				Ends Soon, Get It Now
-			</p>
+                        <p className="bg-[#ff9500] text-white m-0 p-2 text-center ">
+                                {t("nav.promo.beforeStar")} {" "}
+                                <i className="fa-solid fa-star text-yellow-400"></i> {" "}
+                                {t("nav.promo.afterStar")}
+                        </p>
 			<nav className="relative bg-white ">
 				<div className="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
 					<div className="relative flex h-16 items-center justify-between">
@@ -30,7 +38,7 @@ export default function Nav() {
 								aria-controls="mobile-menu"
 								aria-expanded={isMenuOpen}
 							>
-								<span className="sr-only">Open main menu</span>
+                                                                <span className="sr-only">{t("nav.openMenu")}</span>
 								<svg
 									className={`block size-6 ${isMenuOpen ? "hidden" : "block"}`}
 									fill="none"
@@ -63,9 +71,9 @@ export default function Nav() {
 						</div>
 						<div className="flex flex-1 items-center justify-center sm:items-stretch sm:justify-start">
 							<div className="flex shrink-0 items-center">
-								<img
-									src="/images/logo.png"
-									alt="Your Company"
+                                                                <img
+                                                                        src="/images/logo.png"
+                                                                        alt={t("nav.logoAlt")}
 									className="h-8 w-auto rounded-md"
 								/>
 							</div>
@@ -75,45 +83,45 @@ export default function Nav() {
 										to="/"
 										className="rounded-md px-3 py-2 text-sm font-medium text-black hover:bg-gray-200 hover:text-black"
 									>
-										Home
+                                                                                {t("nav.menu.home")}
 									</Link>
 									<Link
 										to="/courses"
 										className="rounded-md px-3 py-2 text-sm font-medium text-black hover:bg-gray-200 hover:text-black"
 									>
-										Courses
+                                                                                {t("nav.menu.courses")}
 									</Link>
 									{user && (
 										<Link
 											to="/my-courses"
 											className="rounded-md px-3 py-2 text-sm font-medium text-black hover:bg-gray-200 hover:text-black"
 										>
-											My Courses
+                                                                                        {t("nav.menu.myCourses")}
 										</Link>
 									)}
 									<Link
 										to="/about"
 										className="rounded-md px-3 py-2 text-sm font-medium text-black hover:bg-gray-200 hover:text-black"
 									>
-										About Us
+                                                                                {t("nav.menu.about")}
 									</Link>
 									<Link
 										to="/pricing"
 										className="rounded-md px-3 py-2 text-sm font-medium text-black hover:bg-gray-200 hover:text-black"
 									>
-										Pricing
+                                                                                {t("nav.menu.pricing")}
 									</Link>
 									<Link
 										to="/contact"
 										className="rounded-md px-3 py-2 text-sm font-medium text-black hover:bg-gray-200 hover:text-black"
 									>
-										Contact
+                                                                                {t("nav.menu.contact")}
 									</Link>
 									<Link
 										to="/wishlist"
 										className="rounded-md px-3 py-2 text-sm font-medium text-black hover:bg-gray-200 hover:text-black"
 									>
-										wishlist
+                                                                                {t("nav.menu.wishlist")}
 									</Link>
 								</div>
 							</div>
@@ -124,7 +132,7 @@ export default function Nav() {
 									onClick={toggleLang}
 									className="bg-[#ff9500] text-white px-3 py-1 rounded rounded focus:outline-none focus:ring-0 w-full disabled:opacity-50 disabled:cursor-not-allowed"
 								>
-									{i18n.language === "en" ? "AR" : "EN"}
+                                                                        {i18n.language === "en" ? t("nav.language.short.ar") : t("nav.language.short.en")}
 								</button>
 							</div>
 							<div className="hidden sm:flex items-center ml-4">
@@ -132,29 +140,29 @@ export default function Nav() {
 									<>
 										<Link to="register">
 											<MyButton bgColor="#e4e4e7" textColor="text-gray-800">
-												sign up
+                                                                                                {t("nav.auth.signup")}
 											</MyButton>
 										</Link>
 										<div className="relative ml-3">
 											<Link to="login">
 												<MyButton bgColor="#ff9500" textColor="text-white">
-													login
+                                                                                                        {t("nav.auth.login")}
 												</MyButton>
 											</Link>
 										</div>
 									</>
 								) : (
 									<>
-										<span className="mr-3 text-sm">
-											Welcome, {user.displayName || user.email}
-										</span>
+                                                                                <span className="mr-3 text-sm">
+                                                                                        {t("nav.auth.welcome", { name: userName })}
+                                                                                </span>
 										<div className="relative ml-3">
 											<MyButton
 												bgColor="#ff9500"
 												textColor="text-white"
 												onClick={logout}
 											>
-												logout
+                                                                                                {t("nav.auth.logout")}
 											</MyButton>
 										</div>
 									</>
@@ -173,13 +181,13 @@ export default function Nav() {
 							to="/"
 							className="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-200 hover:text-black"
 						>
-							Home
+                                                        {t("nav.menu.home")}
 						</Link>
 						<Link
 							to="/Courses"
 							className="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-200 hover:text-black"
 						>
-							Courses
+                                                        {t("nav.menu.courses")}
 						</Link>
 						
 						{user && (
@@ -187,26 +195,26 @@ export default function Nav() {
 								to="/my-courses"
 								className="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-200 hover:text-black"
 							>
-								My Courses
+                                                                {t("nav.menu.myCourses")}
 							</Link>
 						)}
 						<Link
 							to="/about"
 							className="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-200 hover:text-black"
 						>
-							About Us
+                                                        {t("nav.menu.about")}
 						</Link>
 						<Link
 							to="/pricing"
 							className="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-200 hover:text-black"
 						>
-							Pricing
+                                                        {t("nav.menu.pricing")}
 						</Link>
 						<Link
 							to="/contact"
 							className="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-200 hover:text-black"
 						>
-							Contact
+                                                        {t("nav.menu.contact")}
 						</Link>
 						<hr className="my-4" />
 						<div className="px-2">
@@ -214,27 +222,27 @@ export default function Nav() {
 								onClick={toggleLang}
 								className="w-full bg-[#ff9500] text-white px-3 py-2 my-2 rounded text-base font-medium"
 							>
-								{i18n.language === "en"
-									? "Switch to Arabic"
-									: " switch to English"}
+                                                                {i18n.language === "en"
+                                                                        ? t("nav.language.switchToArabic")
+                                                                        : t("nav.language.switchToEnglish")}
 							</button>
 							{!user ? (
 								<>
 									<Link to="login">
 										<div className="w-full text-center bg-[#ff9500] text-gray-800 px-3 py-2 my-2 rounded text-base font-medium">
-											login
+                                                                                        {t("nav.auth.login")}
 										</div>
 									</Link>
 									<Link to="register">
 										<div className="w-full text-center bg-[#e4e4e7] text-gray-800 px-3 py-2 my-2 rounded text-base font-medium">
-											sign up
+                                                                                        {t("nav.auth.signup")}
 										</div>
 									</Link>
 								</>
 							) : (
 								<>
 									<p className="text-center mb-2">
-										Welcome, {user.displayName || user.email}
+                                                                                {t("nav.auth.welcome", { name: userName })}
 									</p>
 
 									
@@ -242,7 +250,7 @@ export default function Nav() {
 										onClick={logout}
 										className="w-full text-center bg-[#ff9500] text-white px-3 py-2 my-2 rounded text-base font-medium"
 									>
-										logout
+                                                                                {t("nav.auth.logout")}
 									</button>
 								</>
 							)}

--- a/src/localization/ar/translation.json
+++ b/src/localization/ar/translation.json
@@ -1,5 +1,36 @@
 {
-	"navbar": {
+        "nav": {
+                "logoAlt": "شركتك",
+                "openMenu": "افتح القائمة الرئيسية",
+                "promo": {
+                        "beforeStar": "دورة مجانية",
+                        "afterStar": "ينتهي العرض قريبًا، احصل عليه الآن"
+                },
+                "menu": {
+                        "home": "الرئيسية",
+                        "courses": "الكورسات",
+                        "myCourses": "كورساتي",
+                        "about": "من نحن",
+                        "pricing": "الأسعار",
+                        "contact": "تواصل معنا",
+                        "wishlist": "المفضلة"
+                },
+                "auth": {
+                        "signup": "إنشاء حساب",
+                        "login": "تسجيل الدخول",
+                        "logout": "تسجيل الخروج",
+                        "welcome": "مرحبًا، {{name}}"
+                },
+                "language": {
+                        "short": {
+                                "en": "EN",
+                                "ar": "AR"
+                        },
+                        "switchToArabic": "التبديل إلى العربية",
+                        "switchToEnglish": "التبديل إلى الإنجليزية"
+                }
+        },
+        "navbar": {
 		"home": "الرئيسية",
 		"courses": "الكورسات",
 		"my courses": "كورساتي",

--- a/src/localization/en/translation.json
+++ b/src/localization/en/translation.json
@@ -1,14 +1,35 @@
 {
-	"nav": {
-		"logoAlt": "Your Company",
-		"openMenu": "Open main menu",
-		"promo": {
-			"beforeStar": "Free Course",
-			"afterStar": "Sale Ends Soon, Get It Now"
-		},
-		"switchToArabic": "Switch to Arabic",
-		"switchToEnglish": "Switch to English"
-	},
+        "nav": {
+                "logoAlt": "Your Company",
+                "openMenu": "Open main menu",
+                "promo": {
+                        "beforeStar": "Free Course",
+                        "afterStar": "Sale Ends Soon, Get It Now"
+                },
+                "menu": {
+                        "home": "Home",
+                        "courses": "Courses",
+                        "myCourses": "My Courses",
+                        "about": "About Us",
+                        "pricing": "Pricing",
+                        "contact": "Contact",
+                        "wishlist": "Wishlist"
+                },
+                "auth": {
+                        "signup": "Sign Up",
+                        "login": "Login",
+                        "logout": "Logout",
+                        "welcome": "Welcome, {{name}}"
+                },
+                "language": {
+                        "short": {
+                                "en": "EN",
+                                "ar": "AR"
+                        },
+                        "switchToArabic": "Switch to Arabic",
+                        "switchToEnglish": "Switch to English"
+                }
+        },
 	"navbar": {
 		"home": "Home",
 		"courses": "Courses",


### PR DESCRIPTION
## Summary
- replace hard-coded navigation labels with `t()` calls for the banner, menus, auth buttons, and welcome text
- add the required navigation, auth, language toggle, and wishlist keys to the English and Arabic locale files
- ensure language toggling updates the document direction for RTL rendering

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cc1a880e6c832ea3911dbdc465f3bc